### PR TITLE
Fix bloomberg repositories & people github links

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,14 +153,14 @@
         <div id="statistics" class="grid-1 alpha header">
           <h1>Statistics</h1>
           <p>
-            <a href="https://github.com/bloomberg/repositories"><span id="num-repos"><img src="assets/spinner.gif" /></span> public repos</a>
+            <a href="https://github.com/orgs/bloomberg/repositories"><span id="num-repos"><img src="assets/spinner.gif" /></span> public repos</a>
             <br>
-            <a href="https://github.com/bloomberg?tab=members"><span id="num-members"><img src="assets/spinner.gif" /></span> members</a>
+            <a href="https://github.com/orgs/bloomberg/people"><span id="num-members"><img src="assets/spinner.gif" /></span> members</a>
           </p>
         </div>
 
         <div id="recently-updated" class="grid-2 omega header">
-          <h1>Recently updated <a href="https://github.com/bloomberg/repositories">View Repositories on GitHub</a></h1>
+          <h1>Recently updated <a href="https://github.com/orgs/bloomberg/repositories">View Repositories on GitHub</a></h1>
           <ol id="recently-updated-repos"></ol>
         </div>
       </div>


### PR DESCRIPTION
Add `orgs` to url path, outdated links returned 404 error